### PR TITLE
Homepage redesign: editorial aesthetic and venture framing

### DIFF
--- a/app/Section.tsx
+++ b/app/Section.tsx
@@ -2,25 +2,42 @@ import { cn } from "@/lib/utils";
 
 export interface SectionProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string;
+  eyebrow?: string;
+  align?: "left" | "center";
 }
 
 export const Section: React.FC<SectionProps> = ({
   title,
+  eyebrow,
+  align = "left",
   children,
   className,
   ...props
 }) => {
   return (
     <section
-      className={cn("w-full max-w-7xl mx-auto px-8", className)}
+      className={cn("w-full max-w-5xl mx-auto px-6 md:px-10", className)}
       {...props}
     >
-      <div className="text-center mb-16">
-        <h2 className="text-5xl font-bold text-gray-900 mb-4">
-          {title}
-        </h2>
-        <div className="w-24 h-1 bg-gradient-to-r from-gray-400 to-gray-600 mx-auto rounded-full"></div>
-      </div>
+      {(title || eyebrow) && (
+        <header
+          className={cn(
+            "mb-12 md:mb-16",
+            align === "center" && "text-center"
+          )}
+        >
+          {eyebrow && (
+            <div className="text-xs uppercase tracking-[0.18em] text-ink-muted mb-4">
+              {eyebrow}
+            </div>
+          )}
+          {title && (
+            <h2 className="font-display text-4xl md:text-5xl text-ink leading-tight text-balance">
+              {title}
+            </h2>
+          )}
+        </header>
+      )}
       {children}
     </section>
   );

--- a/app/components/Boids.tsx
+++ b/app/components/Boids.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type Boid = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+};
+
+const FLOCK = 6;
+const NEIGHBOR_RADIUS = 140;
+const SEPARATION_RADIUS = 50;
+const MAX_SPEED = 1.6;
+const MIN_SPEED = 0.45;
+const CURSOR_PULL = 0.045;
+const CURSOR_TIMEOUT = 1800;
+
+export function Boids() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const parent = canvas.parentElement;
+    if (!parent) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const reduceMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+
+    const resize = () => {
+      const rect = parent.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+      dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+
+    const boids: Boid[] = Array.from({ length: FLOCK }, () => {
+      const angle = Math.random() * Math.PI * 2;
+      return {
+        x: Math.random() * width,
+        y: Math.random() * height,
+        vx: Math.cos(angle) * MAX_SPEED * 0.6,
+        vy: Math.sin(angle) * MAX_SPEED * 0.6,
+      };
+    });
+
+    const cursor = { x: width / 2, y: height / 2, t: 0 };
+    let scrollImpulse = 0;
+    let lastScrollY =
+      typeof window !== "undefined" ? window.scrollY : 0;
+
+    const onPointerMove = (e: PointerEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      cursor.x = e.clientX - rect.left;
+      cursor.y = e.clientY - rect.top;
+      cursor.t = performance.now();
+    };
+    const onScroll = () => {
+      const dy = window.scrollY - lastScrollY;
+      scrollImpulse += dy * 0.18;
+      lastScrollY = window.scrollY;
+    };
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", resize);
+
+    let raf = 0;
+    const tick = () => {
+      ctx.clearRect(0, 0, width, height);
+
+      const cursorActive =
+        !reduceMotion && performance.now() - cursor.t < CURSOR_TIMEOUT;
+
+      for (let i = 0; i < boids.length; i++) {
+        const b = boids[i];
+
+        let alignX = 0;
+        let alignY = 0;
+        let cohX = 0;
+        let cohY = 0;
+        let sepX = 0;
+        let sepY = 0;
+        let neighbors = 0;
+
+        for (let j = 0; j < boids.length; j++) {
+          if (i === j) continue;
+          const o = boids[j];
+          const dx = o.x - b.x;
+          const dy = o.y - b.y;
+          const d2 = dx * dx + dy * dy;
+          if (d2 < NEIGHBOR_RADIUS * NEIGHBOR_RADIUS) {
+            neighbors++;
+            alignX += o.vx;
+            alignY += o.vy;
+            cohX += o.x;
+            cohY += o.y;
+            if (d2 < SEPARATION_RADIUS * SEPARATION_RADIUS && d2 > 0.001) {
+              const d = Math.sqrt(d2);
+              sepX -= dx / d;
+              sepY -= dy / d;
+            }
+          }
+        }
+
+        if (neighbors > 0) {
+          alignX = alignX / neighbors - b.vx;
+          alignY = alignY / neighbors - b.vy;
+          cohX = cohX / neighbors - b.x;
+          cohY = cohY / neighbors - b.y;
+        }
+
+        b.vx += alignX * 0.04 + cohX * 0.0008 + sepX * 0.18;
+        b.vy += alignY * 0.04 + cohY * 0.0008 + sepY * 0.18;
+
+        if (cursorActive) {
+          const dx = cursor.x - b.x;
+          const dy = cursor.y - b.y;
+          const d = Math.sqrt(dx * dx + dy * dy);
+          if (d > 1) {
+            b.vx += (dx / d) * CURSOR_PULL;
+            b.vy += (dy / d) * CURSOR_PULL;
+          }
+        }
+
+        b.vy += scrollImpulse * 0.06;
+
+        const speed = Math.sqrt(b.vx * b.vx + b.vy * b.vy);
+        if (speed > MAX_SPEED) {
+          b.vx = (b.vx / speed) * MAX_SPEED;
+          b.vy = (b.vy / speed) * MAX_SPEED;
+        } else if (speed < MIN_SPEED && speed > 0) {
+          b.vx = (b.vx / speed) * MIN_SPEED;
+          b.vy = (b.vy / speed) * MIN_SPEED;
+        }
+
+        b.x += b.vx;
+        b.y += b.vy;
+
+        const margin = 16;
+        if (b.x < -margin) b.x = width + margin;
+        else if (b.x > width + margin) b.x = -margin;
+        if (b.y < -margin) b.y = height + margin;
+        else if (b.y > height + margin) b.y = -margin;
+
+        const angle = Math.atan2(b.vy, b.vx);
+        ctx.save();
+        ctx.translate(b.x, b.y);
+        ctx.rotate(angle);
+        ctx.fillStyle = "rgba(29, 85, 89, 0.7)";
+        ctx.beginPath();
+        ctx.moveTo(9, 0);
+        ctx.lineTo(-6, 4.5);
+        ctx.lineTo(-3, 0);
+        ctx.lineTo(-6, -4.5);
+        ctx.closePath();
+        ctx.fill();
+        ctx.restore();
+      }
+
+      scrollImpulse *= 0.88;
+      if (Math.abs(scrollImpulse) < 0.01) scrollImpulse = 0;
+
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="absolute inset-0 h-full w-full pointer-events-none"
+      aria-hidden="true"
+    />
+  );
+}

--- a/app/components/Contact.tsx
+++ b/app/components/Contact.tsx
@@ -1,37 +1,80 @@
+'use client';
+
+import { useState } from "react";
+
 export function Contact() {
+    const [email, setEmail] = useState("");
+
+    const handleSubscribe = (e: React.FormEvent) => {
+        e.preventDefault();
+        const trimmed = email.trim();
+        if (!trimmed) return;
+        const subject = encodeURIComponent("Subscribe — NGI investor updates");
+        const body = encodeURIComponent(
+            `Please add ${trimmed} to the monthly investor updates list.`
+        );
+        window.location.href = `mailto:connor@networkgoods.institute?subject=${subject}&body=${body}`;
+    };
+
     return (
-        <section id="contact" className="w-full max-w-4xl mx-auto px-8" itemScope itemType="https://schema.org/Organization">
-            <div className="text-center mb-16">
-                <h2 className="text-5xl font-bold text-gray-900 mb-4">
-                    Get In Touch
-                </h2>
-                <div className="w-24 h-1 bg-gradient-to-r from-gray-400 to-gray-600 mx-auto rounded-full"></div>
-            </div>
-
-            <div className="bg-gradient-to-r from-gray-900 to-gray-800 rounded-3xl p-10 text-white text-center">
-                <div className="max-w-2xl mx-auto">
-                    <h3 className="text-2xl font-bold mb-6 text-blue-300">Connect With Us</h3>
-                    <p className="text-gray-300 leading-relaxed mb-8">
-                        Reach out via email to discuss our research and projects.
+        <section
+            id="contact"
+            className="w-full max-w-5xl mx-auto px-6 md:px-10"
+            itemScope
+            itemType="https://schema.org/Organization"
+        >
+            <div className="grid grid-cols-1 md:grid-cols-5 gap-12 md:gap-20 border-t border-rule pt-16 md:pt-24">
+                <div className="md:col-span-2">
+                    <div className="text-xs uppercase tracking-[0.18em] text-ink-muted mb-4">
+                        Stay in touch
+                    </div>
+                    <h2 className="font-display text-4xl md:text-5xl text-ink leading-tight mb-6">
+                        Monthly briefing
+                    </h2>
+                    <p className="text-ink-soft text-base md:text-lg leading-relaxed max-w-md">
+                        A short letter each month on what we&apos;re building, what we&apos;re reading, and where we&apos;d welcome help. Sent to investors, collaborators, and friends.
                     </p>
+                </div>
 
-                    <a
-                        href="mailto:connor@networkgoods.institute"
-                        className="inline-flex items-center gap-3 px-8 py-4 bg-emerald-500 hover:bg-emerald-600 text-white rounded-xl transition-colors font-medium text-lg"
-                        aria-label="Email Network Goods Institute"
-                    >
-                        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                        </svg>
-                        Email Us
-                    </a>
+                <div className="md:col-span-3 flex flex-col gap-10">
+                    <form onSubmit={handleSubscribe} className="flex flex-col sm:flex-row gap-3">
+                        <label htmlFor="email" className="sr-only">Email address</label>
+                        <input
+                            id="email"
+                            type="email"
+                            required
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            placeholder="you@domain.com"
+                            className="flex-1 px-4 py-3 bg-paper-soft border border-rule rounded-sm text-ink placeholder:text-ink-muted focus:outline-none focus:border-[var(--accent)] transition-colors"
+                        />
+                        <button
+                            type="submit"
+                            className="px-6 py-3 bg-[var(--accent)] hover:bg-[var(--accent-soft)] text-[var(--paper)] rounded-sm font-medium transition-colors"
+                        >
+                            Subscribe
+                        </button>
+                    </form>
+
+                    <div className="border-t border-rule pt-10">
+                        <div className="text-xs uppercase tracking-[0.18em] text-ink-muted mb-3">
+                            Or reach out directly
+                        </div>
+                        <a
+                            href="mailto:connor@networkgoods.institute"
+                            className="font-display text-2xl md:text-3xl accent-link"
+                            aria-label="Email Network Goods Institute"
+                        >
+                            connor@networkgoods.institute
+                        </a>
+                    </div>
                 </div>
             </div>
 
             <meta itemProp="name" content="Network Goods Institute" />
-            <meta itemProp="description" content="Network Goods Institute builds coordination mechanisms for collective intelligence and externality pricing using counterfactual reasoning, economic incentives, and epistemic values." />
+            <meta itemProp="description" content="Network Goods Institute builds coordination mechanisms for collective intelligence and public-goods funding." />
             <meta itemProp="url" content="https://networkgoods.institute" />
             <meta itemProp="email" content="connor@networkgoods.institute" />
         </section>
     );
-} 
+}

--- a/app/components/Disclosure.tsx
+++ b/app/components/Disclosure.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+
+interface DisclosureProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+export function Disclosure({ label, children }: DisclosureProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border-t border-rule">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="w-full py-3 flex justify-between items-center gap-3 text-left text-xs uppercase tracking-[0.18em] text-ink-muted hover:text-ink transition-colors"
+      >
+        <span>{label}</span>
+        <span
+          className={`shrink-0 leading-none text-base transition-transform duration-200 ${open ? "rotate-45" : ""}`}
+          aria-hidden="true"
+        >
+          +
+        </span>
+      </button>
+      <div
+        className={`grid transition-all duration-300 ${open ? "grid-rows-[1fr] opacity-100 pb-4" : "grid-rows-[0fr] opacity-0"}`}
+      >
+        <div className="overflow-hidden">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/FAQ.tsx
+++ b/app/components/FAQ.tsx
@@ -10,27 +10,27 @@ interface FAQItem {
 const faqData: FAQItem[] = [
     {
         question: "What is the Network Goods Institute?",
-        answer: "The Network Goods Institute is a research organization focused on building coordination mechanisms for collective intelligence and externality pricing using counterfactual reasoning, economic incentives, and epistemic values."
+        answer: "NGI is a research organization building coordination mechanisms — protocols, incentives, and governance systems that help groups reason and decide together. We work at the intersection of mechanism design, collective intelligence, and economic infrastructure."
     },
     {
         question: "What are coordination mechanisms?",
-        answer: "Coordination mechanisms are systems designed to help groups make better decisions collectively. They include protocols, incentive structures, and governance systems that align individual actions with collective goals."
+        answer: "Systems that help groups make better decisions collectively. Markets are coordination mechanisms; so are courts, peer review, and elections. We design new ones for problems the existing ones don't solve well."
     },
     {
-        question: "How does counterfactual reasoning work?",
-        answer: "Counterfactual reasoning involves thinking about 'what would have happened otherwise' - analyzing alternative scenarios to better understand causation and make more informed decisions about resource allocation and policy."
+        question: "What do you mean by epistemic incentives?",
+        answer: "Public reasoning today rewards conviction over calibration and narrative dominance over accuracy. Our work — the Negation Game, Litmus, Louie — builds infrastructure where being right and being willing to change your mind both pay off, and where the reasoning behind a decision can be surfaced, contested, and recorded."
     },
     {
         question: "What is the Negation Game?",
-        answer: "The Negation Game is a protocol layer for reasoned disagreement that uses economic incentives and epistemic values to reward intellectual honesty and evidence-based reasoning in discussions."
+        answer: "A protocol for reasoned disagreement. Participants stake credibility on claims, and the system rewards those willing to update in light of stronger arguments. It's designed to make intellectual honesty economically rational."
     },
     {
         question: "How do Index Wallets work?",
-        answer: "Index Wallets are programmable wallets that enable voluntary taxation through economic mechanisms, creating wealth-equalizing dynamics while funding public goods through selfish taxation principles."
+        answer: "Index Wallets are programmable wallets that let people and institutions accept payment in values-embedded vector currencies. The result is a market mechanism for funding public goods — voluntary taxation that benefits the payer."
     },
     {
-        question: "Who can use these coordination mechanisms?",
-        answer: "Our coordination mechanisms are designed for organizations, communities, and individuals interested in improving group decision-making, funding public goods, or implementing more effective governance systems."
+        question: "Who can use these mechanisms?",
+        answer: "Researchers, civic institutions, funders, protocol teams, and communities trying to coordinate at scale. If you're working on a problem where collective reasoning or public-goods funding is the bottleneck, we'd like to hear from you."
     }
 ];
 
@@ -42,62 +42,72 @@ export function FAQ() {
     };
 
     return (
-        <section id="faq" className="w-full max-w-4xl mx-auto px-8" itemScope itemType="https://schema.org/FAQPage">
-            <div className="text-center mb-16">
-                <h2 className="text-5xl font-bold text-gray-900 mb-4">
-                    Frequently Asked Questions
+        <section
+            id="faq"
+            className="w-full max-w-3xl mx-auto px-6 md:px-10"
+            itemScope
+            itemType="https://schema.org/FAQPage"
+        >
+            <header className="mb-12 md:mb-16">
+                <div className="text-xs uppercase tracking-[0.18em] text-ink-muted mb-4">
+                    Questions
+                </div>
+                <h2 className="font-display text-4xl md:text-5xl text-ink leading-tight">
+                    Frequently asked
                 </h2>
-                <div className="w-24 h-1 bg-gradient-to-r from-gray-400 to-gray-600 mx-auto rounded-full"></div>
-            </div>
+            </header>
 
-            <div className="space-y-4">
-                {faqData.map((faq, index) => (
-                    <div
-                        key={index}
-                        className="bg-white rounded-2xl shadow-lg border border-gray-100 overflow-hidden"
-                        itemScope
-                        itemProp="mainEntity"
-                        itemType="https://schema.org/Question"
-                    >
-                        <button
-                            className="w-full px-8 py-6 text-left flex justify-between items-center hover:bg-gray-50 transition-colors"
-                            onClick={() => toggleFAQ(index)}
-                            aria-expanded={openIndex === index}
-                            aria-controls={`faq-answer-${index}`}
+            <div className="border-t border-rule">
+                {faqData.map((faq, index) => {
+                    const isOpen = openIndex === index;
+                    return (
+                        <div
+                            key={index}
+                            className="border-b border-rule"
+                            itemScope
+                            itemProp="mainEntity"
+                            itemType="https://schema.org/Question"
                         >
-                            <h3 className="text-xl font-semibold text-gray-900" itemProp="name">
-                                {faq.question}
-                            </h3>
-                            <div className={`transform transition-transform duration-200 ${openIndex === index ? 'rotate-180' : ''}`}>
-                                <svg
-                                    className="w-6 h-6 text-gray-600"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    viewBox="0 0 24 24"
+                            <button
+                                className="w-full py-6 text-left flex justify-between items-baseline gap-6 group"
+                                onClick={() => toggleFAQ(index)}
+                                aria-expanded={isOpen}
+                                aria-controls={`faq-answer-${index}`}
+                            >
+                                <h3
+                                    className="font-display text-xl md:text-2xl text-ink leading-snug group-hover:text-accent transition-colors"
+                                    itemProp="name"
+                                >
+                                    {faq.question}
+                                </h3>
+                                <span
+                                    className={`shrink-0 text-ink-muted text-2xl leading-none transition-transform duration-200 ${isOpen ? "rotate-45" : ""}`}
                                     aria-hidden="true"
                                 >
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                                </svg>
-                            </div>
-                        </button>
+                                    +
+                                </span>
+                            </button>
 
-                        <div
-                            id={`faq-answer-${index}`}
-                            className={`overflow-hidden transition-all duration-300 ${openIndex === index ? 'max-h-96 pb-6' : 'max-h-0'
-                                }`}
-                            itemScope
-                            itemProp="acceptedAnswer"
-                            itemType="https://schema.org/Answer"
-                        >
-                            <div className="px-8">
-                                <p className="text-gray-700 leading-relaxed" itemProp="text">
-                                    {faq.answer}
-                                </p>
+                            <div
+                                id={`faq-answer-${index}`}
+                                className={`grid transition-all duration-300 ${isOpen ? "grid-rows-[1fr] opacity-100 pb-6" : "grid-rows-[0fr] opacity-0"}`}
+                                itemScope
+                                itemProp="acceptedAnswer"
+                                itemType="https://schema.org/Answer"
+                            >
+                                <div className="overflow-hidden">
+                                    <p
+                                        className="text-ink-soft leading-relaxed text-base md:text-lg max-w-2xl"
+                                        itemProp="text"
+                                    >
+                                        {faq.answer}
+                                    </p>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                ))}
+                    );
+                })}
             </div>
         </section>
     );
-} 
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,137 +3,118 @@
 @tailwind utilities;
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --paper: #f7f4ee;
+  --paper-soft: #fbf9f4;
+  --ink: #161514;
+  --ink-soft: #3a3733;
+  --ink-muted: #6b665e;
+  --rule: #d9d2c5;
+  --accent: #1d5559;
+  --accent-soft: #2a7077;
   --font-inter: 'Inter', sans-serif;
   --font-lora: 'Lora', serif;
 }
 
-/* @media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-} */
-
 body {
-  color: var(--foreground);
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  color: var(--ink);
+  background: var(--paper);
   min-height: 100vh;
   position: relative;
+  font-family: var(--font-inter);
+  font-feature-settings: "ss01", "cv11";
 }
 
 .content--canvas {
+  position: relative;
+  min-height: 100vh;
   display: grid;
-  grid-template-rows: 100px 1fr 60px;
+  grid-template-rows: auto 1fr auto;
   align-items: center;
   justify-items: center;
-  min-height: 100vh;
   padding: 2rem;
-  padding-bottom: 0;
-  gap: 6rem;
+  gap: 4rem;
   font-family: var(--font-inter);
-  position: relative;
   z-index: 1;
-}
-
-#particles-canvas {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-  pointer-events: none;
-}
-
-.section {
-  padding: 4rem;
-  width: 100%;
-  max-width: 96rem;
-  min-height: 100vh;
 }
 
 @layer utilities {
   .text-balance {
     text-wrap: balance;
   }
-
-  .text-gradient {
-    background-clip: text;
-    -webkit-background-clip: text;
-    color: transparent;
-    background-image: linear-gradient(to right, var(--primary), var(--secondary));
+  .font-display {
+    font-family: var(--font-lora);
+    font-feature-settings: "ss01";
+  }
+  .text-ink {
+    color: var(--ink);
+  }
+  .text-ink-soft {
+    color: var(--ink-soft);
+  }
+  .text-ink-muted {
+    color: var(--ink-muted);
+  }
+  .text-accent {
+    color: var(--accent);
+  }
+  .bg-paper {
+    background-color: var(--paper);
+  }
+  .bg-paper-soft {
+    background-color: var(--paper-soft);
+  }
+  .border-rule {
+    border-color: var(--rule);
+  }
+  .accent-link {
+    color: var(--accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+    transition: color 160ms ease;
+  }
+  .accent-link:hover {
+    color: var(--accent-soft);
   }
 }
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 36 33% 95%;
+    --foreground: 30 8% 9%;
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 30 8% 9%;
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
-    --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
-    --accent: 0 0% 96.1%;
-    --accent-foreground: 0 0% 9%;
+    --popover-foreground: 30 8% 9%;
+    --primary: 30 8% 9%;
+    --primary-foreground: 36 33% 95%;
+    --secondary: 36 20% 90%;
+    --secondary-foreground: 30 8% 9%;
+    --muted: 36 20% 90%;
+    --muted-foreground: 30 5% 40%;
+    --accent: 184 50% 23%;
+    --accent-foreground: 36 33% 95%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
+    --border: 36 20% 82%;
+    --input: 36 20% 82%;
+    --ring: 184 50% 23%;
+    --radius: 0.25rem;
   }
-
-  /* .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-  } */
 }
 
 @layer base {
   * {
     @apply border-border;
   }
-
   body {
-    @apply text-foreground font-inter;
+    @apply text-foreground;
   }
-
   html {
     @apply scroll-smooth;
+  }
+  ::selection {
+    background: var(--accent);
+    color: var(--paper);
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,44 +15,32 @@ const lora = Lora({
   display: "swap",
 });
 
-// const geistSans = localFont({
-//   src: "./fonts/GeistVF.woff",
-//   variable: "--font-geist-sans",
-//   weight: "100 900",
-// });
-// const geistMono = localFont({
-//   src: "./fonts/GeistMonoVF.woff",
-//   variable: "--font-geist-mono",
-//   weight: "100 900",
-// });
-
 export const metadata: Metadata = {
   title: {
-    default: "Network Goods Institute - Building Governance for Mars",
+    default: "Network Goods Institute — New paradigms for coordination",
     template: "%s | Network Goods Institute"
   },
-  description: "Network Goods Institute is building the obvious choice of governance for Mars by solving externality pricing, counterfactual reasoning, and power regulation through Index Wallets and Negation Game.",
+  description:
+    "Network Goods Institute designs economic, epistemic, and computational mechanisms for groups to reason and decide together at scale. We build values-embedded money, collective-intelligence platforms, and deliberative civic memory.",
   keywords: [
-    "mars governance",
-    "space governance",
+    "coordination mechanisms",
+    "mechanism design",
+    "collective intelligence",
+    "public goods funding",
     "externality pricing",
-    "counterfactual reasoning",
-    "power regulation",
+    "epistemic incentives",
+    "deliberation",
+    "civic technology",
     "index wallets",
     "negation game",
-    "collective intelligence",
+    "litmus",
+    "louie",
     "quadratic funding",
     "connection-oriented cluster matching",
-    "network goods",
-    "coordination mechanisms",
-    "economic incentives",
-    "epistemic values",
-    "public goods funding",
-    "mechanism design",
-    "protocol design",
+    "values-embedded money",
+    "epistemic infrastructure",
+    "institutional memory",
     "decentralized governance",
-    "blockchain",
-    "crypto economics"
   ],
   authors: [{ name: "Network Goods Institute" }],
   creator: "Network Goods Institute",
@@ -67,26 +55,28 @@ export const metadata: Metadata = {
     canonical: "/",
   },
   openGraph: {
-    title: "Network Goods Institute - Building Governance for Mars",
-    description: "Building the obvious choice of governance for Mars by solving externality pricing, counterfactual reasoning, and power regulation through Index Wallets and Negation Game.",
+    title: "Network Goods Institute — New paradigms for coordination",
+    description:
+      "Economic, epistemic, and computational mechanisms for groups to reason and decide together at scale — values-embedded money, collective-intelligence platforms, and deliberative civic memory.",
     url: "https://networkgoods.institute",
     siteName: "Network Goods Institute",
     locale: "en_US",
     type: "website",
     images: [
       {
-        url: "/mars.jpg",
-        width: 512,
-        height: 384,
-        alt: "Network Goods Institute - Building Governance for Mars",
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Network Goods Institute",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Network Goods Institute - Building Governance for Mars",
-    description: "Building the obvious choice of governance for Mars by solving externality pricing, counterfactual reasoning, and power regulation through Index Wallets and Negation Game.",
-    images: ["/mars.jpg"],
+    title: "Network Goods Institute — New paradigms for coordination",
+    description:
+      "Economic, epistemic, and computational mechanisms for groups to reason and decide together at scale.",
+    images: ["/og-image.png"],
   },
   robots: {
     index: true,
@@ -99,41 +89,42 @@ export const metadata: Metadata = {
       "max-snippet": -1,
     },
   },
-  // verification: {
-  //   google: "your-google-verification-code",
-  // },
 };
 
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Organization",
   name: "Network Goods Institute",
-  description: "Network Goods Institute is building the obvious choice of governance for Mars by solving externality pricing, counterfactual reasoning, and power regulation through Index Wallets and Negation Game.",
+  description:
+    "Network Goods Institute designs economic, epistemic, and computational mechanisms for groups to reason and decide together at scale.",
   url: "https://networkgoods.institute",
   logo: "https://networkgoods.institute/favicon.ico",
   foundingDate: "2024",
   areaServed: "Worldwide",
   email: "connor@networkgoods.institute",
   knowsAbout: [
-    "Mars Governance",
-    "Space Governance",
+    "Coordination Mechanisms",
+    "Mechanism Design",
+    "Collective Intelligence",
+    "Public Goods Funding",
     "Externality Pricing",
-    "Counterfactual Reasoning",
-    "Power Regulation",
+    "Epistemic Incentives",
+    "Deliberation",
+    "Civic Technology",
     "Index Wallets",
     "Negation Game",
-    "Collective Intelligence",
+    "Litmus",
+    "Louie",
     "Quadratic Funding",
     "Connection-Oriented Cluster Matching",
-    "Coordination Mechanisms",
-    "Economic Incentives",
-    "Epistemic Values",
-    "Public Goods Funding",
-    "Mechanism Design"
+    "Values-Embedded Money",
+    "Epistemic Infrastructure",
+    "Institutional Memory"
   ],
   sameAs: [
     "https://play.negationgame.com/",
-    "https://www.indexwallets.org/"
+    "https://www.indexwallets.org/",
+    "https://litmus.bio/"
   ],
   hasOfferCatalog: {
     "@type": "OfferCatalog",
@@ -141,15 +132,31 @@ const jsonLd = {
     itemListElement: [
       {
         "@type": "ResearchProject",
+        name: "Index Wallets",
+        description:
+          "Programmable wallets for values-embedded vector currencies — a market mechanism for funding public goods.",
+        url: "https://preprint.indexwallets.org/"
+      },
+      {
+        "@type": "ResearchProject",
         name: "Negation Game",
-        description: "A protocol layer for reasoned disagreement: powered by economic incentives, governed by epistemic values, and designed for minds willing to change.",
+        description:
+          "A protocol layer for reasoned disagreement: economic incentives, epistemic values, and minds willing to change.",
         url: "https://paragraph.com/@ngi/info-market-overton"
       },
       {
         "@type": "ResearchProject",
-        name: "Index Wallet",
-        description: "Voluntary taxation, wealth equalization, and funding for public goods.",
-        url: "https://preprint.indexwallets.org/"
+        name: "Litmus",
+        description:
+          "AI-powered, expert-augmented forecasting for FDA drug approvals — calibrated, transparent, and auditable.",
+        url: "https://litmus.bio/"
+      },
+      {
+        "@type": "ResearchProject",
+        name: "Louie",
+        description:
+          "Civic deliberative memory: making the public record of municipal government searchable, sourced, and answerable to the public.",
+        url: "https://mississauga-demo.pages.dev/#/louie"
       }
     ]
   }
@@ -168,12 +175,11 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
         <link rel="canonical" href="https://networkgoods.institute" />
-        <meta name="theme-color" content="#6366f1" />
+        <meta name="theme-color" content="#1d5559" />
         <link rel="manifest" href="/manifest.json" />
         <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
       </head>
       <body className={`${inter.variable} ${lora.variable} antialiased`}>
-
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ const projects: Project[] = [
     tagline: "Voluntary taxation, wealth equalization, funding for public goods.",
     body: "A programmable wallet that accepts payment in values-embedded vector currencies. The result is a market mechanism for funding public goods — one in which paying voluntary taxes is in the payer's own interest. We've published a preprint setting out the formal model, and a working demo.",
     problem: "Externality pricing",
-    marketSize: "Payment rails — Visa & Mastercard process $30T+/yr; Stripe ~$1T+.",
+    marketSize: "Global payments industry revenue ~$2.4T/yr; Visa + Mastercard combined market cap ~$1.1T.",
     links: [
       { label: "Read the preprint", href: "https://preprint.indexwallets.org/" },
       { label: "Try the demo", href: "https://www.indexwallets.org/" },
@@ -35,10 +35,10 @@ const projects: Project[] = [
     tagline: "A protocol layer for reasoned disagreement.",
     body: "A discussion platform that pairs economic incentives with epistemic values. Participants stake credibility on claims; the system rewards those willing to update in light of stronger arguments. It is designed for groups that need to reason together honestly — and for minds willing to change.",
     problem: "Epistemic incentives",
-    marketSize: "Prediction markets — Polymarket + Kalshi crossed $10B+ in 2024 volume, growing fast.",
+    marketSize: "Prediction-market platforms ~$3B combined valuation (Polymarket, Kalshi); broader online-discourse market is hundreds of billions annually.",
     links: [
       { label: "Read the essay", href: "https://paragraph.com/@ngi/info-market-overton" },
-      { label: "Play", href: "https://play.negationgame.com/" },
+      { label: "negationgame.com", href: "https://negationgame.com/" },
     ],
     image: { src: "/negationgame.jpg", alt: "Negation Game" },
   },
@@ -47,7 +47,7 @@ const projects: Project[] = [
     tagline: "AI-powered prediction for FDA drug approvals.",
     body: "Litmus combines AI research tools, a curated expert network, and a structured forecast elicitation workflow to produce calibrated predictions on biotech outcomes. It is built around a core question in collective-intelligence research: how do you systematically extract what humans know that AI doesn't, through a process that is rigorous, reproducible, and fully transparent? Developed in collaboration with Elanor Davies, with support from NGI.",
     problem: "Epistemic incentives",
-    marketSize: "Expert networks ($1.5B+) and financial data terminals ($30B+).",
+    marketSize: "Expert networks $1.5B+ annual revenue; financial data terminals (Bloomberg ~$13B/yr) sit in the $30B+ category.",
     links: [{ label: "litmus.bio", href: "https://litmus.bio/" }],
   },
   {
@@ -55,7 +55,7 @@ const projects: Project[] = [
     tagline: "Civic deliberative memory.",
     body: "Louie turns the public record of municipal government into something residents and officials can actually use. It ingests transcripts, agendas, and minutes, and makes them searchable in plain language — every answer linked back to the exact moment in the original meeting. Underneath sits a structured argument map: who said what, what was debated, what was decided, and what was left open. A demo of the first deployment is live with transcripts from the City of Mississauga in Ontario, with active outreach to other municipalities ahead of the October 2026 elections.",
     problem: "Epistemic incentives",
-    marketSize: "Civic & govtech — $50B+ in US municipal IT alone.",
+    marketSize: "US municipal IT spend ~$50B/yr; Tyler Technologies (incumbent) ~$25B market cap.",
     links: [{ label: "View the demo", href: "https://mississauga-demo.pages.dev/#/louie" }],
   },
 ];
@@ -140,10 +140,10 @@ export default function Home() {
       </header>
 
       <main className="flex flex-col gap-32 md:gap-40 py-32 md:py-40 border-t border-rule">
-        <Section id="approach" eyebrow="Approach" title="Three coordination failures. Trillions in unrealized value.">
+        <Section id="approach" eyebrow="Approach" title="Three coordination failures shape the world we&rsquo;re stuck in.">
           <div className="max-w-3xl mb-16 md:mb-20">
             <p className="text-ink-soft text-lg md:text-xl leading-relaxed">
-              The world coordinates through payment rails that don&rsquo;t price externalities, discourse platforms that reward heat over light, and civic systems with no memory. Tens of trillions of dollars flow through these mechanisms every year — and they were built for a smaller, slower world. Replacing them is a species-critical problem with commensurate upside.
+              The world coordinates through payment rails that don&rsquo;t price externalities, discourse platforms that reward heat over light, and civic systems with no memory. The mechanisms were built for a smaller, slower world. The problems they leave behind are real and human-scale; so are the returns for solving them.
             </p>
           </div>
 
@@ -157,7 +157,7 @@ export default function Home() {
               </p>
               <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
                 <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
-                Payment rails &mdash; Visa &amp; Mastercard process $30T+ annually; Stripe ~$1T+.
+                Global payments industry revenue ~$2.4T/yr; Visa + Mastercard combined market cap ~$1.1T.
               </div>
               <Disclosure label="Examples in the news">
                 <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
@@ -186,7 +186,7 @@ export default function Home() {
               </p>
               <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
                 <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
-                Prediction markets ($10B+ and growing); expert networks &amp; financial data ($30B+); civic &amp; govtech ($50B+).
+                Prediction-market platforms ~$3B combined valuation (Polymarket, Kalshi); expert networks $1.5B+ revenue; financial data terminals $30B+ revenue; US municipal IT spend $50B+/yr.
               </div>
               <Disclosure label="Examples in the news">
                 <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
@@ -215,7 +215,7 @@ export default function Home() {
               </p>
               <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
                 <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
-                Antitrust and competition policy moves trillions annually; AI compute and platform governance are the next fronts.
+                Hard to size cleanly: the firms targeted by antitrust and platform-governance fights have $10T+ in combined market cap; AI compute and capability concentration is the next front.
               </div>
               <Disclosure label="Examples in the news">
                 <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
@@ -228,8 +228,8 @@ export default function Home() {
                     Frontier model training has consolidated to four labs and three cloud providers. Governance proposals lag the consolidation.
                   </li>
                   <li>
-                    <span className="font-medium text-ink">DAO governance attacks.</span>{" "}
-                    Token-weighted voting in protocols like Compound has repeatedly let small whales pass proposals against community will.
+                    <span className="font-medium text-ink">Revolving-door regulation.</span>{" "}
+                    Treasury and Fed officials moving to Wall Street, FAA personnel to Boeing, FTC to big tech: industries write the rules they operate under, then hire the people who wrote them. Power buys money buys power.
                   </li>
                 </ul>
               </Disclosure>
@@ -238,7 +238,7 @@ export default function Home() {
 
           <div className="mt-20 md:mt-28 max-w-3xl">
             <p className="font-display text-2xl md:text-3xl text-ink leading-snug text-balance">
-              We&rsquo;re building foundational assets — values-embedded vector money, collective-intelligence platforms, deliberative memory — for a species-critical coordination problem. The leverage is enormous. So is the upside if any one of them lands.
+              We&rsquo;re building foundational assets — values-embedded vector money, collective-intelligence platforms, deliberative memory — for problems facing humanity at scale. The stakes are real. So are the returns for solving them.
             </p>
             <p className="mt-8 text-ink-soft leading-relaxed">
               We draw on mechanisms such as{" "}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,283 +1,366 @@
 import { Section } from "@/app/Section";
 import { FAQ } from "@/app/components/FAQ";
 import { Contact } from "@/app/components/Contact";
+import { Boids } from "@/app/components/Boids";
+import { Disclosure } from "@/app/components/Disclosure";
 import Image from "next/image";
-import Script from "next/script";
 import scrollLogo from "../public/scroll.png";
 import deltaLogo from "../public/delta.png";
 
-export default function Home() {
-  const showProspectiveAffiliations = false;
+type Project = {
+  name: string;
+  tagline: string;
+  body: string;
+  problem: string;
+  marketSize: string;
+  links: { label: string; href: string }[];
+  image?: { src: string; alt: string };
+};
 
+const projects: Project[] = [
+  {
+    name: "Index Wallets",
+    tagline: "Voluntary taxation, wealth equalization, funding for public goods.",
+    body: "A programmable wallet that accepts payment in values-embedded vector currencies. The result is a market mechanism for funding public goods — one in which paying voluntary taxes is in the payer's own interest. We've published a preprint setting out the formal model, and a working demo.",
+    problem: "Externality pricing",
+    marketSize: "Payment rails — Visa & Mastercard process $30T+/yr; Stripe ~$1T+.",
+    links: [
+      { label: "Read the preprint", href: "https://preprint.indexwallets.org/" },
+      { label: "Try the demo", href: "https://www.indexwallets.org/" },
+    ],
+    image: { src: "/index_logo.svg", alt: "Index Wallets" },
+  },
+  {
+    name: "The Negation Game",
+    tagline: "A protocol layer for reasoned disagreement.",
+    body: "A discussion platform that pairs economic incentives with epistemic values. Participants stake credibility on claims; the system rewards those willing to update in light of stronger arguments. It is designed for groups that need to reason together honestly — and for minds willing to change.",
+    problem: "Epistemic incentives",
+    marketSize: "Prediction markets — Polymarket + Kalshi crossed $10B+ in 2024 volume, growing fast.",
+    links: [
+      { label: "Read the essay", href: "https://paragraph.com/@ngi/info-market-overton" },
+      { label: "Play", href: "https://play.negationgame.com/" },
+    ],
+    image: { src: "/negationgame.jpg", alt: "Negation Game" },
+  },
+  {
+    name: "Litmus",
+    tagline: "AI-powered prediction for FDA drug approvals.",
+    body: "Litmus combines AI research tools, a curated expert network, and a structured forecast elicitation workflow to produce calibrated predictions on biotech outcomes. It is built around a core question in collective-intelligence research: how do you systematically extract what humans know that AI doesn't, through a process that is rigorous, reproducible, and fully transparent? Developed in collaboration with Elanor Davies, with support from NGI.",
+    problem: "Epistemic incentives",
+    marketSize: "Expert networks ($1.5B+) and financial data terminals ($30B+).",
+    links: [{ label: "litmus.bio", href: "https://litmus.bio/" }],
+  },
+  {
+    name: "Louie",
+    tagline: "Civic deliberative memory.",
+    body: "Louie turns the public record of municipal government into something residents and officials can actually use. It ingests transcripts, agendas, and minutes, and makes them searchable in plain language — every answer linked back to the exact moment in the original meeting. Underneath sits a structured argument map: who said what, what was debated, what was decided, and what was left open. A demo of the first deployment is live with transcripts from the City of Mississauga in Ontario, with active outreach to other municipalities ahead of the October 2026 elections.",
+    problem: "Epistemic incentives",
+    marketSize: "Civic & govtech — $50B+ in US municipal IT alone.",
+    links: [{ label: "View the demo", href: "https://mississauga-demo.pages.dev/#/louie" }],
+  },
+];
+
+type Collaborator = {
+  name: string;
+  href?: string;
+  image?: { src: string; alt: string; width: number; height: number };
+};
+
+const collaborators: Collaborator[] = [
+  { name: "Scroll", image: { src: scrollLogo.src, alt: "Scroll", width: 56, height: 56 } },
+  { name: "Delta", image: { src: deltaLogo.src, alt: "Delta", width: 56, height: 56 } },
+  { name: "Philip Brown" },
+  { name: "Joel Miller" },
+  { name: "Daniel Ospina" },
+  { name: "Rafael Kaufmann" },
+  { name: "Elanor Davies" },
+  { name: "Spencer Graham" },
+  { name: "Volky" },
+  { name: "Jan Baeriswyl" },
+  { name: "Vaughn", href: "https://buttery.money" },
+  { name: "Eugene Leventhal" },
+  { name: "Jamilya Kamalova" },
+];
+
+export default function Home() {
   return (
     <>
-      <Script src="/bg.js" strategy="afterInteractive" />
-      <div className="content--canvas">
-        <nav className="row-start-1 flex flex-wrap justify-center items-center gap-4 md:gap-8 bg-white/80 backdrop-blur-sm px-4 py-3 md:px-8 md:py-4 rounded-full border border-gray-200 shadow-lg" role="navigation" aria-label="Main navigation">
-          <a
-            className="flex items-center gap-2 text-sm md:text-base hover:underline hover:underline-offset-4 text-gray-700 hover:text-gray-900 transition-colors font-medium"
-            href="#our-approach"
-            aria-label="Navigate to Our Approach section"
-          >
-            Our Approach
-          </a>
-          <a
-            className="flex items-center gap-2 text-sm md:text-base hover:underline hover:underline-offset-4 text-gray-700 hover:text-gray-900 transition-colors font-medium"
-            href="#affiliations"
-            aria-label="Navigate to Affiliations section"
-          >
-            Friends
-          </a>
-          <a
-            className="flex items-center gap-2 text-sm md:text-base hover:underline hover:underline-offset-4 text-gray-700 hover:text-gray-900 transition-colors font-medium"
-            href="#projects"
-            aria-label="Navigate to Projects section"
-          >
-            Projects
-          </a>
-          <a
-            className="flex items-center gap-2 text-sm md:text-base hover:underline hover:underline-offset-4 text-gray-700 hover:text-gray-900 transition-colors font-medium"
-            href="#faq"
-            aria-label="Navigate to FAQ section"
-          >
-            FAQ
-          </a>
-          <a
-            className="flex items-center gap-2 text-sm md:text-base hover:underline hover:underline-offset-4 text-gray-700 hover:text-gray-900 transition-colors font-medium"
-            href="#contact"
-            aria-label="Navigate to Contact section"
-          >
-            Contact
-          </a>
-        </nav>
-        <header className="flex flex-col gap-6 row-start-2 text-center max-w-4xl mx-auto">
-          <h1 className="text-7xl font-bold bg-gradient-to-r from-gray-900 via-gray-700 to-gray-600 bg-clip-text text-transparent leading-tight">
-            Network Goods Institute
-          </h1>
-          <p className="text-3xl tracking-tight text-gray-600 font-light">
-            New paradigms for coordination
-          </p>
-        </header>
+      <header className="relative overflow-hidden">
+        <div className="content--canvas relative">
+          <Boids />
 
-        <div className="row-start-3 flex flex-col items-center gap-4">
-          <p className="text-gray-500 text-sm">Scroll to explore</p>
-          <div className="animate-bounce">
+          <nav
+            className="row-start-1 z-10 flex flex-wrap justify-center items-center gap-x-8 gap-y-3 text-xs uppercase tracking-[0.18em] text-ink-muted"
+            role="navigation"
+            aria-label="Main navigation"
+          >
+            <a href="#approach" className="hover:text-ink transition-colors">
+              Approach
+            </a>
+            <a href="#projects" className="hover:text-ink transition-colors">
+              Projects
+            </a>
+            <a href="#collaborators" className="hover:text-ink transition-colors">
+              Collaborators
+            </a>
+            <a href="#faq" className="hover:text-ink transition-colors">
+              FAQ
+            </a>
+            <a href="#contact" className="hover:text-ink transition-colors">
+              Contact
+            </a>
+          </nav>
+
+          <div className="row-start-2 z-10 flex flex-col gap-8 text-center max-w-4xl mx-auto px-4">
+            <div className="text-xs uppercase tracking-[0.22em] text-ink-muted">
+              Network Goods Institute
+            </div>
+            <h1 className="font-display text-5xl md:text-7xl text-ink leading-[1.05] text-balance">
+              New paradigms <span className="italic text-accent">for coordination.</span>
+            </h1>
+            <p className="text-lg md:text-xl text-ink-soft max-w-2xl mx-auto leading-relaxed">
+              We design economic, epistemic, and computational mechanisms for
+              groups to reason and decide together at scale.
+            </p>
+          </div>
+
+          <div className="row-start-3 z-10 flex flex-col items-center gap-2 text-ink-muted">
+            <span className="text-xs uppercase tracking-[0.18em]">Scroll</span>
             <svg
-              className="w-8 h-8 text-gray-400 animate-pulse"
+              className="w-4 h-4"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
               aria-hidden="true"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7-7-7" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 14l-7 7-7-7" />
             </svg>
           </div>
         </div>
-      </div>
-      <main className="flex items-center flex-col border-t border-gray-200 bg-gradient-to-b from-gray-50 to-white gap-32 py-32">
+      </header>
 
-        <Section id="our-approach" title="Our Approach">
-          <div className="max-w-4xl mx-auto">
-            <h3 className="text-2xl font-bold text-gray-900 mb-8 text-center">The problems as we see them</h3>
+      <main className="flex flex-col gap-32 md:gap-40 py-32 md:py-40 border-t border-rule">
+        <Section id="approach" eyebrow="Approach" title="Three coordination failures. Trillions in unrealized value.">
+          <div className="max-w-3xl mb-16 md:mb-20">
+            <p className="text-ink-soft text-lg md:text-xl leading-relaxed">
+              The world coordinates through payment rails that don&rsquo;t price externalities, discourse platforms that reward heat over light, and civic systems with no memory. Tens of trillions of dollars flow through these mechanisms every year — and they were built for a smaller, slower world. Replacing them is a species-critical problem with commensurate upside.
+            </p>
+          </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
-              <article className="bg-white rounded-2xl p-8 shadow-lg border border-gray-100">
-                <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center mb-6">
-                  <span className="text-white font-bold text-xl">EP</span>
-                </div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-4">Externality Pricing</h3>
-                <p className="text-gray-600 leading-relaxed mb-4">
-                  How can we make it profitable for companies to fund and create public goods?
-                </p>
-                <div className="text-blue-600 font-medium">Solution: Index Wallets</div>
-              </article>
-
-              <article className="bg-white rounded-2xl p-8 shadow-lg border border-gray-100">
-                <div className="w-16 h-16 bg-gradient-to-br from-purple-500 to-purple-600 rounded-xl flex items-center justify-center mb-6">
-                  <span className="text-white font-bold text-xl">CR</span>
-                </div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-4">Counterfactual Reasoning</h3>
-                <p className="text-gray-600 leading-relaxed mb-4">
-                  How can we understand &quot;what would have happened otherwise&quot; to make better decisions?
-                </p>
-                <div className="text-purple-600 font-medium">Solution: Collective Intelligence</div>
-              </article>
-
-              <article className="bg-white rounded-2xl p-8 shadow-lg border border-gray-100">
-                <div className="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-600 rounded-xl flex items-center justify-center mb-6">
-                  <span className="text-white font-bold text-xl">PR</span>
-                </div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-4">Power Regulation</h3>
-                <p className="text-gray-600 leading-relaxed mb-4">
-                  How can we prevent concentration and abuse of power in governance systems?
-                </p>
-              </article>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-12 md:gap-10 max-w-5xl">
+            <div className="flex flex-col gap-5">
+              <div className="text-xs uppercase tracking-[0.18em] text-accent">
+                Externality pricing
+              </div>
+              <p className="text-ink-soft leading-relaxed">
+                Markets don&rsquo;t price what they don&rsquo;t see. Public goods stay underfunded; harms stay externalized. The opportunity is to make funding them profitable.
+              </p>
+              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
+                <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
+                Payment rails &mdash; Visa &amp; Mastercard process $30T+ annually; Stripe ~$1T+.
+              </div>
+              <Disclosure label="Examples in the news">
+                <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
+                  <li>
+                    <span className="font-medium text-ink">Climate damage.</span>{" "}
+                    The IPCC&rsquo;s social cost of carbon sits above $185/ton; the global average carbon price is under $5. The gap implies tens of trillions in unpriced future damage.
+                  </li>
+                  <li>
+                    <span className="font-medium text-ink">Open-source infrastructure.</span>{" "}
+                    Log4j and the XZ Utils backdoor exposed how much critical software is maintained by a handful of unpaid volunteers. Value flows to the firms using it; risk pools at the maintainers.
+                  </li>
+                  <li>
+                    <span className="font-medium text-ink">Pandemic preparedness.</span>{" "}
+                    Antibiotic R&amp;D collapsed because new antibiotics weren&rsquo;t profitable; COVID-19 found preparedness systematically underfunded despite decades of warnings.
+                  </li>
+                </ul>
+              </Disclosure>
             </div>
 
-            <article className="bg-gradient-to-r from-gray-900 to-gray-800 rounded-2xl p-8 text-white">
-              <h3 className="text-2xl font-bold mb-6">Our Methods</h3>
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div>
-                  <h4 className="text-lg font-semibold mb-3 text-blue-300">For Externality Pricing</h4>
-                  <p className="text-gray-300 leading-relaxed">
-                    We use values-embedded vector money, a new way to encode social values directly into financial instruments.
-                  </p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-3 text-purple-300">For Counterfactual Reasoning</h4>
-                  <p className="text-gray-300 leading-relaxed">
-                    We build collective intelligence systems through platforms like Negation Game that enable reasoned disagreement and self-invalidating behavior.
-                  </p>
-                </div>
-                <div>
-                  <h4 className="text-lg font-semibold mb-3 text-orange-300">For Power Regulation</h4>
-                  <p className="text-gray-300 leading-relaxed">
-                    We&apos;re inspired by mechanisms such as <a href="https://wtfisqf.com/" target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">quadratic funding</a> and <a href="https://www.gitcoin.co/blog/leveling-the-field-how-connection-oriented-cluster-matching-strengthens-quadratic-funding" target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">connection-oriented cluster matching</a>.
-                  </p>
-                  <div className="mt-4">
-                    <a href="#contact" className="text-white font-bold bg-green-700 px-4 py-2 rounded-xl hover:bg-green-600 transition-colors">Help us solve it</a>
-                  </div>
-                </div>
+            <div className="flex flex-col gap-5">
+              <div className="text-xs uppercase tracking-[0.18em] text-accent">
+                Epistemic incentives
               </div>
-            </article>
+              <p className="text-ink-soft leading-relaxed">
+                Public reasoning rewards conviction over calibration and narrative dominance over accuracy. Better incentives — for being right, and for changing your mind — would reshape how decisions get made.
+              </p>
+              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
+                <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
+                Prediction markets ($10B+ and growing); expert networks &amp; financial data ($30B+); civic &amp; govtech ($50B+).
+              </div>
+              <Disclosure label="Examples in the news">
+                <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
+                  <li>
+                    <span className="font-medium text-ink">The replication crisis.</span>{" "}
+                    Half of published psychology and a third of biomedical findings fail to replicate. Career incentives reward novel positive results, not calibrated uncertainty.
+                  </li>
+                  <li>
+                    <span className="font-medium text-ink">SVB and the 2023 banking run.</span>{" "}
+                    Risk-management consensus was wrong about interest-rate exposure. Few who flagged it ahead of time were rewarded; few who missed it were penalized.
+                  </li>
+                  <li>
+                    <span className="font-medium text-ink">AI risk.</span>{" "}
+                    Frontier labs publicly acknowledge significant existential risk while racing to deploy. No mechanism aligns career success with calibrated public communication.
+                  </li>
+                </ul>
+              </Disclosure>
+            </div>
+
+            <div className="flex flex-col gap-5">
+              <div className="text-xs uppercase tracking-[0.18em] text-accent">
+                Power regulation
+              </div>
+              <p className="text-ink-soft leading-relaxed">
+                Coordination systems concentrate power as easily as they distribute it. Designing against capture is part of the work, not an afterthought.
+              </p>
+              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
+                <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
+                Antitrust and competition policy moves trillions annually; AI compute and platform governance are the next fronts.
+              </div>
+              <Disclosure label="Examples in the news">
+                <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
+                  <li>
+                    <span className="font-medium text-ink">Tech antitrust.</span>{" "}
+                    The FTC and EU have spent a decade unwinding concentration in attention, search, and app distribution — slow, costly, after the fact.
+                  </li>
+                  <li>
+                    <span className="font-medium text-ink">AI compute concentration.</span>{" "}
+                    Frontier model training has consolidated to four labs and three cloud providers. Governance proposals lag the consolidation.
+                  </li>
+                  <li>
+                    <span className="font-medium text-ink">DAO governance attacks.</span>{" "}
+                    Token-weighted voting in protocols like Compound has repeatedly let small whales pass proposals against community will.
+                  </li>
+                </ul>
+              </Disclosure>
+            </div>
+          </div>
+
+          <div className="mt-20 md:mt-28 max-w-3xl">
+            <p className="font-display text-2xl md:text-3xl text-ink leading-snug text-balance">
+              We&rsquo;re building foundational assets — values-embedded vector money, collective-intelligence platforms, deliberative memory — for a species-critical coordination problem. The leverage is enormous. So is the upside if any one of them lands.
+            </p>
+            <p className="mt-8 text-ink-soft leading-relaxed">
+              We draw on mechanisms such as{" "}
+              <a
+                href="https://wtfisqf.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="accent-link"
+              >
+                quadratic funding
+              </a>{" "}
+              and{" "}
+              <a
+                href="https://www.gitcoin.co/blog/leveling-the-field-how-connection-oriented-cluster-matching-strengthens-quadratic-funding"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="accent-link"
+              >
+                connection-oriented cluster matching
+              </a>
+              , and we publish the formal models behind our work alongside the code.
+            </p>
           </div>
         </Section>
 
-        <Section id="affiliations" title="Friends">
-          <div className="max-w-5xl mx-auto">
-            <div className="flex justify-center items-center gap-16 flex-wrap" role="list">
-              <div className="flex flex-col gap-4 items-center p-8 rounded-2xl bg-white shadow-lg border border-gray-100 hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1" role="listitem">
-                <Image
-                  src={scrollLogo}
-                  alt="Scroll - Layer 2 Ethereum scaling solution"
-                  width={128}
-                  height={128}
-                  className="rounded-2xl shadow-lg"
-                  priority
-                />
-                <p className="font-bold text-2xl text-center text-gray-900">Scroll</p>
-              </div>
-              <div className="flex flex-col gap-4 items-center p-8 rounded-2xl bg-white shadow-lg border border-gray-100 hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1" role="listitem">
-                <Image
-                  src={deltaLogo}
-                  alt="Delta - Decentralized trading protocol"
-                  width={128}
-                  height={128}
-                  className="rounded-2xl shadow-lg"
-                  priority
-                />
-                <p className="font-bold text-2xl text-center text-gray-900">Delta</p>
-              </div>
-              {showProspectiveAffiliations && [
-                { name: "Protocol Labs", color: "from-red-400 to-red-500", description: "Decentralized web protocols" },
-                { name: "Metaculus", color: "from-indigo-400 to-indigo-500", description: "Prediction and forecasting platform" },
-                { name: "Uniswap", color: "from-pink-400 to-pink-500", description: "Decentralized exchange protocol" },
-              ].map((affiliation, index) => (
-                <div key={index} className="flex flex-col gap-4 items-center p-8 rounded-2xl bg-white shadow-lg border border-gray-100 opacity-50" role="listitem">
-                  <div className={`w-32 h-32 bg-gradient-to-br ${affiliation.color} rounded-2xl flex items-center justify-center text-white font-bold text-xl shadow-lg`} aria-label={`${affiliation.name} logo placeholder`}>
-                    {affiliation.name.split(' ').map(word => word[0]).join('')}
+        <Section id="projects" eyebrow="Projects" title="What we&rsquo;re building.">
+          <div className="flex flex-col">
+            {projects.map((project, idx) => (
+              <article
+                key={project.name}
+                className={`grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-10 md:py-14 ${idx === 0 ? "border-t" : ""} border-b border-rule`}
+              >
+                <div className="md:col-span-3 flex flex-col gap-4">
+                  <div className="text-xs uppercase tracking-[0.18em] text-ink-muted">
+                    {project.problem}
                   </div>
-                  <p className="font-bold text-2xl text-center text-gray-900">{affiliation.name}</p>
+                  {project.image && (
+                    <Image
+                      src={project.image.src}
+                      alt={project.image.alt}
+                      width={56}
+                      height={56}
+                      className="rounded-sm"
+                    />
+                  )}
+                  <div className="text-xs text-ink-soft border-l border-rule pl-3 leading-relaxed mt-1">
+                    <span className="block uppercase tracking-[0.18em] text-ink-muted mb-1">
+                      Comparable market
+                    </span>
+                    {project.marketSize}
+                  </div>
                 </div>
-              ))}
-            </div>
+
+                <div className="md:col-span-9 flex flex-col gap-5">
+                  <div>
+                    <h3 className="font-display text-3xl md:text-4xl text-ink leading-tight">
+                      {project.name}
+                    </h3>
+                    <p className="font-display italic text-xl text-ink-soft mt-2">
+                      {project.tagline}
+                    </p>
+                  </div>
+                  <p className="text-ink-soft leading-relaxed text-base md:text-lg max-w-2xl">
+                    {project.body}
+                  </p>
+                  <div className="flex flex-wrap gap-x-6 gap-y-2 mt-2">
+                    {project.links.map((link) => (
+                      <a
+                        key={link.href}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="accent-link text-sm md:text-base"
+                      >
+                        {link.label} →
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              </article>
+            ))}
           </div>
         </Section>
 
-        <Section id="projects" title="Projects">
-          <div className="max-w-6xl mx-auto">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-12" role="list">
-              <article className="bg-white rounded-3xl p-10 shadow-xl border border-gray-100 hover:shadow-2xl transition-all duration-300" role="listitem">
-                <header className="flex items-center gap-4 mb-6">
-                  <Image
-                    src="/negationgame.jpg"
-                    alt="Negation Game logo"
-                    width={64}
-                    height={64}
-                    className="rounded-2xl shadow-lg"
-                    priority
-                  />
-                  <h3 className="font-bold text-3xl text-gray-900">The Negation Game</h3>
-                </header>
-                <p className="text-xl text-gray-600 mb-6 leading-relaxed">
-                  A protocol layer for reasoned disagreement: powered by economic incentives, governed by epistemic values, and designed for minds willing to change.
-                </p>
-                <div className="space-y-4 text-gray-700">
-                  <p className="leading-relaxed">
-                    A discussion platform built on principles of epistemic accountability and honest intellectual discourse. Unlike traditional platforms, it implements economic incentives that reward intellectual honesty and evidence-based reasoning.
-                  </p>
-                  <div className="flex gap-4 flex-wrap" role="list" aria-label="Project tags">
-                    <span className="px-3 py-1 bg-indigo-100 text-indigo-700 rounded-full text-sm font-medium" role="listitem">Epistemic Values</span>
-                    <span className="px-3 py-1 bg-purple-100 text-purple-700 rounded-full text-sm font-medium" role="listitem">Economic Incentives</span>
-                    <span className="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm font-medium" role="listitem">Truth-Seeking</span>
-                  </div>
-                </div>
-                <a
-                  href="https://paragraph.com/@ngi/info-market-overton"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 mt-6 px-6 py-3 bg-gradient-to-r from-indigo-500 to-purple-600 text-white rounded-xl hover:from-indigo-600 hover:to-purple-700 transition-all duration-200 font-medium"
-                  aria-label="Learn more about Negation Game project"
-                >
-                  Learn More →
-                </a>
-                <a
-                  href="https://play.negationgame.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 mt-6 ml-4 px-6 py-3 bg-gradient-to-r from-blue-500 to-cyan-600 text-white rounded-xl hover:from-blue-600 hover:to-cyan-700 transition-all duration-200 font-medium"
-                  aria-label="Try out Negation Game"
-                >
-                  Try it out →
-                </a>
-              </article>
-
-              <article className="bg-white rounded-3xl p-10 shadow-xl border border-gray-100 hover:shadow-2xl transition-all duration-300" role="listitem">
-                <header className="flex items-center gap-4 mb-6">
-                  <Image
-                    src="/index_logo.svg"
-                    alt="Index Wallet logo"
-                    width={64}
-                    height={64}
-                    className="rounded-2xl shadow-lg bg-white p-2"
-                    priority
-                  />
-                  <h3 className="font-bold text-3xl text-gray-900">Index Wallets</h3>
-                </header>
-                <p className="text-xl text-gray-600 mb-6 leading-relaxed">
-                  Voluntary taxation, wealth equalization, and funding for public goods.
-                </p>
-                <div className="space-y-4 text-gray-700">
-                  <p className="leading-relaxed">
-                    A programmable wallet that enables voluntary taxation through economic mechanisms. Index wallets create wealth-equalizing dynamics while funding public goods through selfish taxation principles.
-                  </p>
-                  <div className="flex gap-4 flex-wrap" role="list" aria-label="Project tags">
-                    <span className="px-3 py-1 bg-emerald-100 text-emerald-700 rounded-full text-sm font-medium" role="listitem">Public Goods</span>
-                    <span className="px-3 py-1 bg-teal-100 text-teal-700 rounded-full text-sm font-medium" role="listitem">Wealth Equality</span>
-                    <span className="px-3 py-1 bg-green-100 text-green-700 rounded-full text-sm font-medium" role="listitem">Economic Mechanism</span>
-                  </div>
-                </div>
-                <a
-                  href="https://preprint.indexwallets.org/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 mt-6 px-6 py-3 bg-gradient-to-r from-emerald-500 to-teal-600 text-white rounded-xl hover:from-emerald-600 hover:to-teal-700 transition-all duration-200 font-medium"
-                  aria-label="Read Index Wallet preprint research paper"
-                >
-                  Read Preprint →
-                </a>
-                <a
-                  href="https://www.indexwallets.org/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 mt-6 ml-4 px-6 py-3 bg-gradient-to-r from-yellow-500 to-orange-600 text-white rounded-xl hover:from-yellow-600 hover:to-orange-700 transition-all duration-200 font-medium"
-                  aria-label="View Index Wallet demo"
-                >
-                  View Demo →
-                </a>
-              </article>
-            </div>
-          </div>
+        <Section id="collaborators" eyebrow="Our Collaborators" title="People and organizations we work with.">
+          <ul
+            className="flex flex-wrap gap-x-3 gap-y-3 max-w-4xl"
+            role="list"
+          >
+            {collaborators.map((c) => {
+              const inner = (
+                <span className="inline-flex items-center gap-2.5 px-4 py-2.5 border border-rule bg-paper-soft hover:border-[var(--accent)] hover:text-accent transition-colors text-ink rounded-sm text-base">
+                  {c.image && (
+                    <Image
+                      src={c.image.src}
+                      alt={c.image.alt}
+                      width={20}
+                      height={20}
+                      className="rounded-sm"
+                    />
+                  )}
+                  <span className="font-medium">{c.name}</span>
+                  {c.href && (
+                    <span className="text-ink-muted text-sm">
+                      {c.href.replace(/^https?:\/\//, "")}
+                    </span>
+                  )}
+                </span>
+              );
+              return (
+                <li key={c.name} role="listitem">
+                  {c.href ? (
+                    <a href={c.href} target="_blank" rel="noopener noreferrer">
+                      {inner}
+                    </a>
+                  ) : (
+                    inner
+                  )}
+                </li>
+              );
+            })}
+          </ul>
         </Section>
 
         <FAQ />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import scrollLogo from "../public/scroll.png";
 import deltaLogo from "../public/delta.png";
 
 type Project = {
+  slug: string;
   name: string;
   tagline: string;
   body: string;
@@ -19,6 +20,7 @@ type Project = {
 
 const projects: Project[] = [
   {
+    slug: "index-wallets",
     name: "Index Wallets",
     tagline: "Voluntary taxation, wealth equalization, funding for public goods.",
     body: "A programmable wallet that accepts payment in values-embedded vector currencies. The result is a market mechanism for funding public goods — one in which paying voluntary taxes is in the payer's own interest. We've published a preprint setting out the formal model, and a working demo.",
@@ -31,6 +33,7 @@ const projects: Project[] = [
     image: { src: "/index_logo.svg", alt: "Index Wallets" },
   },
   {
+    slug: "negation-game",
     name: "The Negation Game",
     tagline: "A protocol layer for reasoned disagreement.",
     body: "A discussion platform that pairs economic incentives with epistemic values. Participants stake credibility on claims; the system rewards those willing to update in light of stronger arguments. It is designed for groups that need to reason together honestly — and for minds willing to change.",
@@ -43,6 +46,7 @@ const projects: Project[] = [
     image: { src: "/negationgame.jpg", alt: "Negation Game" },
   },
   {
+    slug: "litmus",
     name: "Litmus",
     tagline: "AI-powered prediction for FDA drug approvals.",
     body: "Litmus combines AI research tools, a curated expert network, and a structured forecast elicitation workflow to produce calibrated predictions on biotech outcomes. It is built around a core question in collective-intelligence research: how do you systematically extract what humans know that AI doesn't, through a process that is rigorous, reproducible, and fully transparent? Developed in collaboration with Elanor Davies, with support from NGI.",
@@ -51,6 +55,7 @@ const projects: Project[] = [
     links: [{ label: "litmus.bio", href: "https://litmus.bio/" }],
   },
   {
+    slug: "louie",
     name: "Louie",
     tagline: "Civic deliberative memory.",
     body: "Louie turns the public record of municipal government into something residents and officials can actually use. It ingests transcripts, agendas, and minutes, and makes them searchable in plain language — every answer linked back to the exact moment in the original meeting. Underneath sits a structured argument map: who said what, what was debated, what was decided, and what was left open. A demo of the first deployment is live with transcripts from the City of Mississauga in Ontario, with active outreach to other municipalities ahead of the October 2026 elections.",
@@ -155,9 +160,15 @@ export default function Home() {
               <p className="text-ink-soft leading-relaxed">
                 Markets don&rsquo;t price what they don&rsquo;t see. Public goods stay underfunded; harms stay externalized. The opportunity is to make funding them profitable.
               </p>
-              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
-                <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
-                Global payments industry revenue ~$2.4T/yr; Visa + Mastercard combined market cap ~$1.1T.
+              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed space-y-3">
+                <div>
+                  <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Our approach</span>
+                  <a href="#project-index-wallets" className="accent-link font-medium">Index Wallets ↓</a>
+                </div>
+                <div>
+                  <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
+                  Global payments industry revenue ~$2.4T/yr; Visa + Mastercard combined market cap ~$1.1T.
+                </div>
               </div>
               <Disclosure label="Examples in the news">
                 <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
@@ -184,9 +195,19 @@ export default function Home() {
               <p className="text-ink-soft leading-relaxed">
                 Public reasoning rewards conviction over calibration and narrative dominance over accuracy. Better incentives — for being right, and for changing your mind — would reshape how decisions get made.
               </p>
-              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
-                <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
-                Prediction-market platforms ~$3B combined valuation (Polymarket, Kalshi); expert networks $1.5B+ revenue; financial data terminals $30B+ revenue; US municipal IT spend $50B+/yr.
+              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed space-y-3">
+                <div>
+                  <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Our approach</span>
+                  <span className="font-medium">
+                    <a href="#project-negation-game" className="accent-link">Negation Game ↓</a>,{" "}
+                    <a href="#project-litmus" className="accent-link">Litmus ↓</a>,{" "}
+                    <a href="#project-louie" className="accent-link">Louie ↓</a>
+                  </span>
+                </div>
+                <div>
+                  <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
+                  Prediction-market platforms ~$3B combined valuation (Polymarket, Kalshi); expert networks $1.5B+ revenue; financial data terminals $30B+ revenue; US municipal IT spend $50B+/yr.
+                </div>
               </div>
               <Disclosure label="Examples in the news">
                 <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
@@ -213,9 +234,15 @@ export default function Home() {
               <p className="text-ink-soft leading-relaxed">
                 Coordination systems concentrate power as easily as they distribute it. Designing against capture is part of the work, not an afterthought.
               </p>
-              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed">
-                <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
-                Hard to size cleanly: the firms targeted by antitrust and platform-governance fights have $10T+ in combined market cap; AI compute and capability concentration is the next front.
+              <div className="text-sm text-ink-soft border-l border-rule pl-4 leading-relaxed space-y-3">
+                <div>
+                  <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Our approach</span>
+                  <span className="text-ink">No dedicated project here yet — designing against capture is built into the work below.</span>
+                </div>
+                <div>
+                  <span className="block text-xs uppercase tracking-[0.18em] text-ink-muted mb-1">Comparable market</span>
+                  Hard to size cleanly: the firms targeted by antitrust and platform-governance fights have $10T+ in combined market cap; AI compute and capability concentration is the next front.
+                </div>
               </div>
               <Disclosure label="Examples in the news">
                 <ul className="text-sm text-ink-soft space-y-3 leading-relaxed pt-1">
@@ -269,7 +296,8 @@ export default function Home() {
             {projects.map((project, idx) => (
               <article
                 key={project.name}
-                className={`grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-10 md:py-14 ${idx === 0 ? "border-t" : ""} border-b border-rule`}
+                id={`project-${project.slug}`}
+                className={`grid grid-cols-1 md:grid-cols-12 gap-6 md:gap-12 py-10 md:py-14 scroll-mt-24 ${idx === 0 ? "border-t" : ""} border-b border-rule`}
               >
                 <div className="md:col-span-3 flex flex-col gap-4">
                   <div className="text-xs uppercase tracking-[0.18em] text-ink-muted">


### PR DESCRIPTION
## Summary

- Redesigns the homepage with an editorial palette (warm cream, ink, deep teal accent), Lora display + Inter UI typography, and a 6-boid hero canvas that follows the cursor and reacts to scroll.
- Reframes NGI from a research-org tone to a venture frame: foundational assets for human-scale coordination problems, with revenue/market-cap-based market sizing and a collapsible "Examples in the news" per problem area.
- Renames the second pillar from "Counterfactual reasoning" to "Epistemic incentives" — closer to what the projects (Negation Game, Litmus, Louie) actually address.
- Adds two new projects: **Litmus** (FDA drug-approval forecasting) and **Louie** (civic deliberative memory, with the Mississauga demo).
- Flattens the old Friends section into a single Collaborators tier with Scroll, Delta, and 11 individual contributors.
- Drops the "Mars governance" SEO framing across title, description, OG, Twitter, and JSON-LD; replaces "Help us solve it" CTA with a monthly investor-briefing signup.

## Test plan

- [ ] `pnpm install && pnpm build` — verifies a clean static build.
- [ ] `pnpm dev` and load `/` — check the boids hero, the three approach pillars with their disclosures, project list, collaborator chips, FAQ accordion, and contact form.
- [ ] Verify external links: Index Wallets preprint/demo, Negation Game essay + negationgame.com, Litmus, Louie demo, quadratic-funding + cluster-matching footnotes.
- [ ] Subscribe button opens a mailto to connor@networkgoods.institute (placeholder until an ESP is wired up).
- [ ] Reduced-motion mode disables boid cursor attraction.
- [ ] Mobile (≤640px) layout for the three-column approach grid and the project list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)